### PR TITLE
[Bug] Fix platform-specific Windows dependencies

### DIFF
--- a/MAEs/Hybrid_Transformer_Thanh_Nguyen/requirements.txt
+++ b/MAEs/Hybrid_Transformer_Thanh_Nguyen/requirements.txt
@@ -97,8 +97,8 @@ pytest==8.4.1
 python-dateutil==2.9.0.post0
 python-json-logger==3.3.0
 pytz==2025.2
-pywin32==311
-pywinpty==2.0.15
+pywin32==311; sys_platform == 'win32'
+pywinpty==2.0.15; sys_platform == 'win32'
 PyYAML==6.0.2
 pyzmq==27.0.0
 referencing==0.36.2


### PR DESCRIPTION
Add platform markers to pywin32 and pywinpty to prevent installation failures on Linux and macOS.

These packages only exist on Windows, and without platform markers, pip fails with 'could not find version' errors on non-Windows systems.

This fix allows:
- Windows users to install normally (packages included)
- Linux/Mac users to install successfully (packages skipped)
- Cross-platform CI/CD to work properly