### PR TITLE
[Code Quality] Replace wildcard imports with explicit imports

### DIFF
--- a/MAEs/Hybrid_Transformer_Thanh_Nguyen/src/engine/jetclass_trainer.py
+++ b/MAEs/Hybrid_Transformer_Thanh_Nguyen/src/engine/jetclass_trainer.py
@@ -12,7 +12,10 @@ from torch.distributed import all_gather, all_gather_object
 from .trainer import Trainer
 from ..utils import cleanup_ddp
 from ..utils.data import JetClassDistributedSampler
-from ..utils.viz import *
+from ..utils.viz import (
+    plot_roc_curve,
+    plot_confusion_matrix
+)
 
 
 class JetClassTrainer(Trainer):

--- a/MAEs/Hybrid_Transformer_Thanh_Nguyen/src/engine/mm_trainer.py
+++ b/MAEs/Hybrid_Transformer_Thanh_Nguyen/src/engine/mm_trainer.py
@@ -11,7 +11,6 @@ from torch.distributed import all_gather, all_gather_object
 from .trainer import Trainer
 from ..utils import cleanup_ddp
 from ..utils.data import JetClassDistributedSampler
-from ..utils.viz import *
 
 
 class MaskedModelTrainer(Trainer):

--- a/MAEs/Hybrid_Transformer_Thanh_Nguyen/src/engine/trainer.py
+++ b/MAEs/Hybrid_Transformer_Thanh_Nguyen/src/engine/trainer.py
@@ -30,7 +30,11 @@ from ..utils import (
     cleanup_ddp
 )
 from ..utils.data import JetClassDistributedSampler
-from ..utils.viz import *
+from ..utils.viz import (
+    plot_roc_curve,
+    plot_confusion_matrix,
+    plot_history
+)
 
 
 class Trainer:

--- a/MAEs/Hybrid_Transformer_Thanh_Nguyen/src/utils/viz/__init__.py
+++ b/MAEs/Hybrid_Transformer_Thanh_Nguyen/src/utils/viz/__init__.py
@@ -1,1 +1,17 @@
-from .viz import *
+from .viz import (
+    plot_feature_distribution,
+    plot_particle_reconstruction,
+    plot_history,
+    plot_ssl_history,
+    plot_confusion_matrix,
+    plot_roc_curve
+)
+
+__all__ = [
+    'plot_feature_distribution',
+    'plot_particle_reconstruction',
+    'plot_history',
+    'plot_ssl_history',
+    'plot_confusion_matrix',
+    'plot_roc_curve'
+]

--- a/MAEs/Hybrid_Transformer_Thanh_Nguyen/src/utils/viz/viz.py
+++ b/MAEs/Hybrid_Transformer_Thanh_Nguyen/src/utils/viz/viz.py
@@ -6,6 +6,16 @@ import seaborn as sns
 from sklearn.metrics import confusion_matrix, roc_curve, roc_auc_score
 
 
+__all__ = [
+    'plot_feature_distribution',
+    'plot_particle_reconstruction',
+    'plot_history',
+    'plot_ssl_history',
+    'plot_confusion_matrix',
+    'plot_roc_curve'
+]
+
+
 # Function to visualize the distribution of particle features (pT, eta, phi, E)
 def plot_feature_distribution(X_jets: np.ndarray) -> None:
     feature_names = ['pT', 'eta', 'phi', 'energy']


### PR DESCRIPTION
- Replace 'from ..utils.viz import *' with explicit imports
- Add __all__ declarations to viz.py and viz/__init__.py to define public API
- Import only the functions actually used in each file
- Remove unused import from mm_trainer.py

Benefits:
- Clear visibility of which functions are being used
- Better IDE autocomplete and code navigation
- Easier to find and remove unused imports
- Follows PEP 8 guidelines
- Prevents namespace pollution